### PR TITLE
bump dependency version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-loading-spinner",
   "main": "angular-loading-spinner.js",
-  "version": "v0.0.3",
+  "version": "v0.0.4",
   "homepage": "https://github.com/adonespitogo/angular-loading-spinner",
   "authors": [
     "Adones Pitogo <pitogo.adones@gmail.com>"
@@ -29,6 +29,6 @@
     "tests"
   ],
   "dependencies": {
-    "angular-spinner": "~0.6.1"
+    "angular-spinner": "~0.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-loading-spinner",
-  "version": "v0.0.3",
+  "version": "v0.0.4",
   "description": "AngularJS directive ajax loading indicator.",
   "main": "angular-loading-spinner.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/adonespitogo/angular-loading-spinner",
   "dependencies": {
-    "angular-spinner": "~0.6.1"
+    "angular-spinner": "~0.8.1"
   }
 
 }


### PR DESCRIPTION
angular-spinner v0.7.0 has improved browerify/webpack support,
I would like to use that improvement, so bumping up the version.